### PR TITLE
chore: Add BlockHound custom configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,8 @@ group = "com.ricardocosta"
 version = "0.0.1-SNAPSHOT"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
-application {
-    applicationDefaultJvmArgs = listOf("-XX:+AllowRedefinitionToAddDeleteMethods")
+tasks.getByName<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
+    jvmArgs = listOf("-XX:+AllowRedefinitionToAddDeleteMethods")
 }
 
 repositories {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,4 +26,4 @@ springdoc:
     tagsSorter: alpha
   default-produces-media-type: application/json
   show-actuator: true
-blockhound.active: false
+blockhound.active: true

--- a/src/test/kotlin/com/ricardocosta/api/bank/listeners/BlockHoundRegisterListenerTests.kt
+++ b/src/test/kotlin/com/ricardocosta/api/bank/listeners/BlockHoundRegisterListenerTests.kt
@@ -62,10 +62,7 @@ class BlockHoundRegisterListenerTests {
         ).with(any(ReactiveAdapterRegistry.SpringCoreBlockHoundIntegration::class.java))
 
         // Check if exclusions are setup
-        verify(blockHoundBuilderMock, times(1)).allowBlockingCallsInside(
-            "com.fasterxml.jackson.module.kotlin.KotlinNamesAnnotationIntrospector",
-            "findKotlinParameterName"
-        )
+        verify(blockHoundBuilderMock, times(1)).with(any(BankAPIBlockHoundIntegration::class.java))
 
         // Check if BlockHound is installed
         verify(blockHoundBuilderMock, times(1)).install()
@@ -95,5 +92,30 @@ class BlockHoundRegisterListenerTests {
         blockHoundMock.verifyNoInteractions()
 
         blockHoundMock.close()
+    }
+
+    @Test
+    fun `BankAPIBlockHoundIntegration adds BlockHound exclusions`() {
+        // Setup BlockHound Builder mock
+        val blockHoundBuilderMock = mock(BlockHound.Builder::class.java, RETURNS_SELF)
+
+        val subject = BankAPIBlockHoundIntegration()
+        subject.applyTo(blockHoundBuilderMock)
+
+        // Check if exclusions are setup
+        verify(blockHoundBuilderMock, times(1)).allowBlockingCallsInside(
+            "kotlin.reflect.jvm.internal.impl.builtins.jvm.JvmBuiltInsPackageFragmentProvider",
+            "findPackage"
+        )
+
+        verify(blockHoundBuilderMock, times(1)).allowBlockingCallsInside(
+            "org.hibernate.validator.resourceloading.PlatformResourceBundleLocator",
+            "getResourceBundle"
+        )
+
+        verify(blockHoundBuilderMock, times(1)).allowBlockingCallsInside(
+            "java.util.UUID",
+            "randomUUID"
+        )
     }
 }


### PR DESCRIPTION
Add a custom configuration to BlockHound that will allow us to add exceptions when we hit situations where blocking calls are acceptable.
